### PR TITLE
add differences to retry from lost and pause menu

### DIFF
--- a/Assets/Scripts/Character/Health/HealthAndDamage.cs
+++ b/Assets/Scripts/Character/Health/HealthAndDamage.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class HealthAndDamage : MonoBehaviour
 {
     public int initialLife = 100;
-    public int life;
+    private int life;
     public bool invincible;
     public float invincibleTime = 1f;
     public float stopTime = 0.2f;  // time the player stops after recieving damage
@@ -21,6 +21,15 @@ public class HealthAndDamage : MonoBehaviour
     {
         life = initialLife;
         healtBar.SetMaxHealth(initialLife);
+    }
+
+    public void SetLife(int playerLife) {
+        life = playerLife;
+        healtBar.SetHealth(playerLife);
+    }
+
+    public int GetActualLife() {
+        return life;
     }
 
     public void InflictDamage(int damage)

--- a/Assets/Scripts/Character/Movement/ColliderController.cs
+++ b/Assets/Scripts/Character/Movement/ColliderController.cs
@@ -11,7 +11,8 @@ public class ColliderController : MonoBehaviour
 
         if (other.tag == "SpawnPoint")
         {
-            levelExtras.GetComponent<SpawnSystem>().UpdateLastPlayerPoint(playerNum, other.gameObject);
+            int playerLife = GetComponent<HealthAndDamage>().GetActualLife();
+            levelExtras.GetComponent<SpawnSystem>().UpdateLastPlayerSpawnPoint(playerNum, other.gameObject, playerLife);
         }
 
         if (other.tag == "ExitDoor")

--- a/Assets/Scripts/Level/SpawnSystem.cs
+++ b/Assets/Scripts/Level/SpawnSystem.cs
@@ -6,39 +6,68 @@ public class SpawnSystem : MonoBehaviour
 {
     public GameObject startPositionPlayer1;
     public GameObject startPositionPlayer2;
+    private GameObject[] playerStartPosition = { null, null};
     private GameObject[] actualPlayerSpawnPoint = { null, null };
-    private GameObject[] lastPlayerPoint = { null, null };
-
+    private GameObject[] lastPlayerSpawnPoint = { null, null };
+    private int[] playerLifeInActualSpawnPoint = { 100, 100};
+    private int[] playerLifeInLastSpawnPoint = { 100, 100 };
 
     private void Start()
     {
+        playerStartPosition[0] = startPositionPlayer1;
+        playerStartPosition[1] = startPositionPlayer2;
         actualPlayerSpawnPoint[0] = startPositionPlayer1;
         actualPlayerSpawnPoint[1] = startPositionPlayer2;
-        lastPlayerPoint[0] = startPositionPlayer1;
-        lastPlayerPoint[1] = startPositionPlayer2;
+        lastPlayerSpawnPoint[0] = startPositionPlayer1;
+        lastPlayerSpawnPoint[1] = startPositionPlayer2;
     }
-    public void UpdateLastPlayerPoint(int playerNum, GameObject spawnPoint)
+
+    public void UpdateLastPlayerSpawnPoint(int playerNum, GameObject spawnPoint, int playerLife)
     {
-        lastPlayerPoint[playerNum - 1] = spawnPoint;
-        if (lastPlayerPoint[0].transform.parent == lastPlayerPoint[1].transform.parent)
+        int index = playerNum - 1;
+        lastPlayerSpawnPoint[index] = spawnPoint;
+        playerLifeInLastSpawnPoint[index] = playerLife;
+        if (lastPlayerSpawnPoint[0].transform.parent == lastPlayerSpawnPoint[1].transform.parent)
         {
-            actualPlayerSpawnPoint[0] = lastPlayerPoint[0];
-            actualPlayerSpawnPoint[1] = lastPlayerPoint[1];
+            actualPlayerSpawnPoint[0] = lastPlayerSpawnPoint[0];
+            actualPlayerSpawnPoint[1] = lastPlayerSpawnPoint[1];
+            playerLifeInActualSpawnPoint[0] = playerLifeInLastSpawnPoint[0];
+            playerLifeInActualSpawnPoint[1] = playerLifeInLastSpawnPoint[1];
         }
     }
 
-    public void SendPlayersToSpawnsPositions()
+    public void SendPlayersToLastSpawnsPositions()
     {
         GameObject[] players;
         players = GameObject.FindGameObjectsWithTag("Player");
         foreach (GameObject player in players)
         {
-            player.GetComponent<HealthAndDamage>().RestartLife();
             int playerNum = player.GetComponent<PlayerData>().playerNum;
+            int index = playerNum - 1;
+
+            player.GetComponent<HealthAndDamage>().SetLife(playerLifeInLastSpawnPoint[index]);
 
             CharacterController playerCharacterController = player.GetComponent<CharacterController>();
             playerCharacterController.enabled = false;
-            playerCharacterController.transform.position = actualPlayerSpawnPoint[playerNum - 1].transform.position;
+            playerCharacterController.transform.position = actualPlayerSpawnPoint[index].transform.position;
+            playerCharacterController.enabled = true;
+        }
+    }
+
+    public void SendPlayersToInitialSpawnsPositions()
+    {
+        GameObject[] players;
+        players = GameObject.FindGameObjectsWithTag("Player");
+        foreach (GameObject player in players)
+        {
+            int playerNum = player.GetComponent<PlayerData>().playerNum;
+            int index = playerNum - 1;
+
+            player.GetComponent<HealthAndDamage>().RestartLife();
+
+            CharacterController playerCharacterController = player.GetComponent<CharacterController>();
+            playerCharacterController.enabled = false;
+            playerCharacterController.transform.position = playerStartPosition[index].transform.position;
             playerCharacterController.enabled = true;
         }
     }

--- a/Assets/Scripts/Menus/LostMenu.cs
+++ b/Assets/Scripts/Menus/LostMenu.cs
@@ -23,7 +23,7 @@ public class LostMenu : MonoBehaviour
     }
     public void Retry()
     {
-        levelExtras.GetComponent<SpawnSystem>().SendPlayersToSpawnsPositions();
+        levelExtras.GetComponent<SpawnSystem>().SendPlayersToInitialSpawnsPositions();
         levelExtras.GetComponent<LevelTimeScale>().StartLevel();
         SetActiveMenuItems(false);
     }

--- a/Assets/Scripts/Menus/PauseMenu.cs
+++ b/Assets/Scripts/Menus/PauseMenu.cs
@@ -52,7 +52,7 @@ public class PauseMenu : MonoBehaviour
 
     public void Retry()
     {
-        levelExtras.GetComponent<SpawnSystem>().SendPlayersToSpawnsPositions();
+        levelExtras.GetComponent<SpawnSystem>().SendPlayersToLastSpawnsPositions();
         Resume();
     }
 


### PR DESCRIPTION
From lost menu it goes back to the initial spawn point with all the player life.
From pause menu it goes back to the last check point with the life that the player have when it passed over the point.